### PR TITLE
Ignore component list download error and try to start player anyway

### DIFF
--- a/versions-config/remote-components-win.cfg
+++ b/versions-config/remote-components-win.cfg
@@ -1,6 +1,6 @@
 ForceStable=false
 LatestRolloutPercent=10
-InstallerVersion=2015.10.08.11.00
+InstallerVersion=2015.10.12.12.27
 InstallerURL=http://install-versions.risevision.com/rvplayer-installer.exe
 
 BrowserVersionStable=44.0.2403.157

--- a/windows-installer/setup.nsi
+++ b/windows-installer/setup.nsi
@@ -356,7 +356,7 @@ Section -Main SEC0000
 
     ${DetailPrint} "Unable to retrieve information about components."
     StrCpy $Errors "$Errors$\n$\tUnable to retrieve information about components."
-    ${MyAbort} "Installation has failed."
+    Goto DeleteConfig
     
     SetVariables:
     ClearErrors
@@ -456,9 +456,10 @@ Section -Main SEC0000
     ;${ListPrint} "ChromiumURL" $ChromiumURL
     ;${ListPrint} "JavaVersion" $JavaVersion
     ;${ListPrint} "JavaURL" $JavaURL
-        
+
+    DeleteConfig:
     Delete "$PLUGINSDIR\${BaseName}.config"
-           
+    
     ;-------------------
     ; Installer upgrade
     


### PR DESCRIPTION
This PR restores the way the previous installer handled version checks' errors

@tejohnso please review