### PR TITLE
Don't update installer unless 14.04LTS

### DIFF
--- a/linux-installer/rvplayer-installer.sh
+++ b/linux-installer/rvplayer-installer.sh
@@ -577,26 +577,13 @@ fi
 
 if ! $SILENT; then rvp_accept_terms; fi
 
-rvp_get_update
-
-# check for installer upgrade
-
-if [ -n "$VALUE_INSTALLER_VERSION" ] && [ -n "$VALUE_INSTALLER_URL" ] && [ "$VALUE_INSTALLER_VERSION" != "$VERSION" ]
-then 
-	rvp_download_and_run_installer
-else
-	echo "Installer is up to date."
-fi
-
-rvp_install_script
-
 # If running an old version of Ubuntu, do not upgrade components and try to run Player if it is installed
-if [[ "$OSVER" < "14.04" ]]
+if [[ "$OSVER" != "14.04" ]]
 then
   echo ""
   echo "*******************************************************************************************"
   echo ""
-  echo "Latest Rise Player requires Ubuntu 14.04 to run. Attempting to use previous installation..."
+  echo "Latest Rise Player requires Ubuntu 14.04 to run. Attempting to use existing installation..."
   echo ""
   echo "*******************************************************************************************"
   echo ""
@@ -609,6 +596,19 @@ then
 	rvp_start_player
 	exit 0
 fi
+
+rvp_get_update
+
+# check for installer upgrade
+
+if [ -n "$VALUE_INSTALLER_VERSION" ] && [ -n "$VALUE_INSTALLER_URL" ] && [ "$VALUE_INSTALLER_VERSION" != "$VERSION" ]
+then 
+	rvp_download_and_run_installer
+else
+	echo "Installer is up to date."
+fi
+
+rvp_install_script
 
 rm -rf $TEMP_PATH/$CHROME_LINUX
 


### PR DESCRIPTION
@fjvallarino It looks like we were allowing installer upgrades even if less than 14.04.  This changes it so that it doesn't even do the component checking or installer version checking unless we're on 14.04.  It also demands *exactly* 14.04.