### PR TITLE
Update .cfg files to use latest version of Electron installer

### DIFF
--- a/versions-config/electron-remote-components-lnx-32.cfg
+++ b/versions-config/electron-remote-components-lnx-32.cfg
@@ -1,7 +1,7 @@
 ForceStable=false
 LatestRolloutPercent=5
 
-InstallerElectronVersion=2016.01.06.13.00
+InstallerElectronVersion=2016.1.21.0.50
 InstallerElectronURL=http://install-versions.risevision.com/rvplayer-installer-lnx-32.tar.gz
 
 BrowserVersionStable=47.0.2526.80

--- a/versions-config/electron-remote-components-lnx-64.cfg
+++ b/versions-config/electron-remote-components-lnx-64.cfg
@@ -1,7 +1,7 @@
 ForceStable=false
 LatestRolloutPercent=5
 
-InstallerElectronVersion=2016.01.06.13.00
+InstallerElectronVersion=2016.1.21.0.50
 InstallerElectronURL=http://install-versions.risevision.com/rvplayer-installer-lnx-64.tar.gz
 
 BrowserVersionStable=47.0.2526.80

--- a/versions-config/electron-remote-components-win-32.cfg
+++ b/versions-config/electron-remote-components-win-32.cfg
@@ -1,7 +1,7 @@
 ForceStable=false
 LatestRolloutPercent=5
 
-InstallerElectronVersion=2016.01.06.13.00
+InstallerElectronVersion=2016.1.21.0.50
 InstallerElectronURL=http://install-versions.risevision.com/rvplayer-installer-win-32.tar.gz
 
 BrowserVersionStable=47.0.2526.80

--- a/versions-config/electron-remote-components-win-64.cfg
+++ b/versions-config/electron-remote-components-win-64.cfg
@@ -1,7 +1,7 @@
 ForceStable=false
 LatestRolloutPercent=5
 
-InstallerElectronVersion=2016.01.06.13.00
+InstallerElectronVersion=2016.1.21.0.50
 InstallerElectronURL=http://install-versions.risevision.com/rvplayer-installer-win-64.tar.gz
 
 BrowserVersionStable=47.0.2526.106


### PR DESCRIPTION
Update .cfg files to use latest version of Electron installer (there should not be functioning installers using these .cfg files because of the googleapis.com error, this is just for completeness)

@tejohnso @ahmedalsudani please review