### PR TITLE
Move the old (version2) installer

### DIFF
--- a/versions-config/remote-components-win.cfg
+++ b/versions-config/remote-components-win.cfg
@@ -1,7 +1,7 @@
 ForceStable=false
 LatestRolloutPercent=0
 InstallerVersion=2015.10.12.12.27
-InstallerURL=http://install-versions.risevision.com/rvplayer-installer.exe
+InstallerURL=http://installer2.risevision.com/rvplayer-installer.exe
 
 BrowserVersionStable=46.0.2490.80
 BrowserVersionLatest=47.0.2526.80


### PR DESCRIPTION
Google has flagged it as malware and it's causing the entire components
bucket to be flagged.  This will isolate the offending exe into its own
bucket.
@fjvallarino @ahmedalsudani 