### PR TITLE
Update player version just for rollout% enablement

### DIFF
--- a/versions-config/electron-remote-components-lnx-32.cfg
+++ b/versions-config/electron-remote-components-lnx-32.cfg
@@ -23,7 +23,7 @@ JavaURLStable=http://install-versions.risevision.com/jre-7u80-lnx-32.tar.gz
 JavaURLLatest=http://install-versions.risevision.com/jre-7u80-lnx-32.tar.gz
 
 PlayerVersionStable=2016.02.05.10.00
-PlayerVersionLatest=2016.02.05.10.00
+PlayerVersionLatest=2016.02.11.21.00
 
 PlayerURLStable=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz
 PlayerURLLatest=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz

--- a/versions-config/electron-remote-components-lnx-32.json
+++ b/versions-config/electron-remote-components-lnx-32.json
@@ -16,7 +16,7 @@
   "JavaURLStable": "http://install-versions.risevision.com/jre-7u80-lnx-32.tar.gz",
   "JavaURLLatest": "http://install-versions.risevision.com/jre-7u80-lnx-32.tar.gz",
   "PlayerVersionStable": "2016.02.05.10.00",
-  "PlayerVersionLatest": "2016.02.05.10.00",
+  "PlayerVersionLatest": "2016.02.11.21.00",
   "PlayerURLStable": "http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz",
   "PlayerURLLatest": "http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz"
 }

--- a/versions-config/electron-remote-components-lnx-64.cfg
+++ b/versions-config/electron-remote-components-lnx-64.cfg
@@ -23,7 +23,7 @@ JavaURLStable=http://install-versions.risevision.com/jre-7u80-lnx-64.tar.gz
 JavaURLLatest=http://install-versions.risevision.com/jre-7u80-lnx-64.tar.gz
 
 PlayerVersionStable=2016.02.05.10.00
-PlayerVersionLatest=2016.02.05.10.00
+PlayerVersionLatest=2016.02.11.21.00
 
 PlayerURLStable=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz
 PlayerURLLatest=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz

--- a/versions-config/electron-remote-components-lnx-64.json
+++ b/versions-config/electron-remote-components-lnx-64.json
@@ -16,7 +16,7 @@
   "JavaURLStable": "http://install-versions.risevision.com/jre-7u80-lnx-64.tar.gz",
   "JavaURLLatest": "http://install-versions.risevision.com/jre-7u80-lnx-64.tar.gz",
   "PlayerVersionStable": "2016.02.05.10.00",
-  "PlayerVersionLatest": "2016.02.05.10.00",
+  "PlayerVersionLatest": "2016.02.11.21.00",
   "PlayerURLStable": "http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz",
   "PlayerURLLatest": "http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz"
 }

--- a/versions-config/electron-remote-components-win-32.cfg
+++ b/versions-config/electron-remote-components-win-32.cfg
@@ -23,7 +23,7 @@ JavaURLStable=http://install-versions.risevision.com/jre-7u80-win-32.tar.gz
 JavaURLLatest=http://install-versions.risevision.com/jre-7u80-win-32.tar.gz
 
 PlayerVersionStable=2016.02.05.10.00
-PlayerVersionLatest=2016.02.05.10.00
+PlayerVersionLatest=2016.02.11.21.00
 
 PlayerURLStable=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz
 PlayerURLLatest=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz

--- a/versions-config/electron-remote-components-win-32.json
+++ b/versions-config/electron-remote-components-win-32.json
@@ -16,7 +16,7 @@
   "JavaURLStable": "http://install-versions.risevision.com/jre-7u80-win-32.tar.gz",
   "JavaURLLatest": "http://install-versions.risevision.com/jre-7u80-win-32.tar.gz",
   "PlayerVersionStable": "2016.02.05.10.00",
-  "PlayerVersionLatest": "2016.02.05.10.00",
+  "PlayerVersionLatest": "2016.02.11.21.00",
   "PlayerURLStable": "http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz",
   "PlayerURLLatest": "http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz"
 }

--- a/versions-config/electron-remote-components-win-64.cfg
+++ b/versions-config/electron-remote-components-win-64.cfg
@@ -23,7 +23,7 @@ JavaURLStable=http://install-versions.risevision.com/jre-7u80-win-64.tar.gz
 JavaURLLatest=http://install-versions.risevision.com/jre-7u80-win-64.tar.gz
 
 PlayerVersionStable=2016.02.05.10.00
-PlayerVersionLatest=2016.02.05.10.00
+PlayerVersionLatest=2016.02.11.21.00
 
 PlayerURLStable=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz
 PlayerURLLatest=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz

--- a/versions-config/electron-remote-components-win-64.json
+++ b/versions-config/electron-remote-components-win-64.json
@@ -16,7 +16,7 @@
   "JavaURLStable": "http://install-versions.risevision.com/jre-7u80-win-64.tar.gz",
   "JavaURLLatest": "http://install-versions.risevision.com/jre-7u80-win-64.tar.gz",
   "PlayerVersionStable": "2016.02.05.10.00",
-  "PlayerVersionLatest": "2016.02.05.10.00",
+  "PlayerVersionLatest": "2016.02.11.21.00",
   "PlayerURLStable": "http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz",
   "PlayerURLLatest": "http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.tar.gz"
 }

--- a/versions-config/remote-components-lnx-32.cfg
+++ b/versions-config/remote-components-lnx-32.cfg
@@ -22,7 +22,7 @@ JavaURLStable=http://install-versions.risevision.com/jre-7u80-linux-32.zip
 JavaURLLatest=http://install-versions.risevision.com/jre-7u80-linux-32.zip
 
 PlayerVersionStable=2016.02.05.10.00
-PlayerVersionLatest=2016.02.05.10.00
+PlayerVersionLatest=2016.02.11.21.00
 
 PlayerURLStable=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.zip
 PlayerURLLatest=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.zip

--- a/versions-config/remote-components-lnx-64.cfg
+++ b/versions-config/remote-components-lnx-64.cfg
@@ -22,7 +22,7 @@ JavaURLStable=http://install-versions.risevision.com/jre-7u80-linux-64.zip
 JavaURLLatest=http://install-versions.risevision.com/jre-7u80-linux-64.zip
 
 PlayerVersionStable=2016.02.05.10.00
-PlayerVersionLatest=2016.02.05.10.00
+PlayerVersionLatest=2016.02.11.21.00
 
 PlayerURLStable=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.zip
 PlayerURLLatest=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.zip

--- a/versions-config/remote-components-win.cfg
+++ b/versions-config/remote-components-win.cfg
@@ -22,7 +22,7 @@ JavaURLStable=http://install-versions.risevision.com/jre-7.9-32bit.zip
 JavaURLLatest=http://install-versions.risevision.com/jre-7.9-32bit.zip
 
 PlayerVersionStable=2016.02.05.10.00
-PlayerVersionLatest=2016.02.05.10.00
+PlayerVersionLatest=2016.02.11.21.00
 
 PlayerURLStable=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.zip
 PlayerURLLatest=http://install-versions.risevision.com/RisePlayer-2016-02-05-10-00.zip


### PR DESCRIPTION
The rollout percentage isn't considered if the display's player version
is already on "latest" player version.  This sets the player version
forward so that the percentage is considered.  But the same player jar
will be downloaded and reinstalled.

@ahmedalsudani @fjvallarino 