### PR TITLE
Rollback fix

### DIFF
--- a/versions-config/electron-remote-components-lnx-32.cfg
+++ b/versions-config/electron-remote-components-lnx-32.cfg
@@ -1,7 +1,7 @@
 ForceStable=false
-LatestRolloutPercent=2
+LatestRolloutPercent=100
 
-InstallerElectronVersion=2016.3.9.14.37
+InstallerElectronVersion=2016.2.24.17.21
 InstallerElectronURL=http://install-versions.risevision.com/rvplayer-installer-lnx-32.tar.gz
 
 BrowserVersionStable=48.0.2564.116

--- a/versions-config/electron-remote-components-lnx-32.json
+++ b/versions-config/electron-remote-components-lnx-32.json
@@ -1,7 +1,7 @@
 {
   "ForceStable": false,
-  "LatestRolloutPercent": 2,
-  "InstallerElectronVersion": "2016.3.9.14.37",
+  "LatestRolloutPercent": 100,
+  "InstallerElectronVersion": "2016.2.24.17.21",
   "InstallerElectronURL": "http://install-versions.risevision.com/rvplayer-installer-lnx-32.tar.gz",
   "BrowserVersionStable": "48.0.2564.116",
   "BrowserVersionLatest": "48.0.2564.116",

--- a/versions-config/electron-remote-components-lnx-64.cfg
+++ b/versions-config/electron-remote-components-lnx-64.cfg
@@ -1,7 +1,7 @@
 ForceStable=false
-LatestRolloutPercent=2
+LatestRolloutPercent=100
 
-InstallerElectronVersion=2016.3.9.14.37
+InstallerElectronVersion=2016.2.24.17.21
 InstallerElectronURL=http://install-versions.risevision.com/rvplayer-installer-lnx-64.tar.gz
 
 BrowserVersionStable=48.0.2564.116

--- a/versions-config/electron-remote-components-lnx-64.json
+++ b/versions-config/electron-remote-components-lnx-64.json
@@ -1,7 +1,7 @@
 {
   "ForceStable": false,
-  "LatestRolloutPercent": 2,
-  "InstallerElectronVersion": "2016.3.9.14.37",
+  "LatestRolloutPercent": 100,
+  "InstallerElectronVersion": "2016.2.24.17.21",
   "InstallerElectronURL": "http://install-versions.risevision.com/rvplayer-installer-lnx-64.tar.gz",
   "BrowserVersionStable": "48.0.2564.116",
   "BrowserVersionLatest": "48.0.2564.116",

--- a/versions-config/electron-remote-components-win-32.cfg
+++ b/versions-config/electron-remote-components-win-32.cfg
@@ -1,7 +1,7 @@
 ForceStable=false
-LatestRolloutPercent=2
+LatestRolloutPercent=100
 
-InstallerElectronVersion=2016.3.9.14.37
+InstallerElectronVersion=2016.2.24.17.21
 InstallerElectronURL=http://install-versions.risevision.com/rvplayer-installer-win-32.tar.gz
 
 BrowserVersionStable=48.0.2564.116

--- a/versions-config/electron-remote-components-win-32.json
+++ b/versions-config/electron-remote-components-win-32.json
@@ -1,7 +1,7 @@
 {
   "ForceStable": false,
-  "LatestRolloutPercent": 2,
-  "InstallerElectronVersion": "2016.3.9.14.37",
+  "LatestRolloutPercent": 100,
+  "InstallerElectronVersion": "2016.2.24.17.21",
   "InstallerElectronURL": "http://install-versions.risevision.com/rvplayer-installer-win-32.tar.gz",
   "BrowserVersionStable": "48.0.2564.116",
   "BrowserVersionLatest": "48.0.2564.116",

--- a/versions-config/electron-remote-components-win-64.cfg
+++ b/versions-config/electron-remote-components-win-64.cfg
@@ -1,7 +1,7 @@
 ForceStable=false
-LatestRolloutPercent=2
+LatestRolloutPercent=100
 
-InstallerElectronVersion=2016.3.9.14.37
+InstallerElectronVersion=2016.2.24.17.21
 InstallerElectronURL=http://install-versions.risevision.com/rvplayer-installer-win-64.tar.gz
 
 BrowserVersionStable=48.0.2564.116

--- a/versions-config/electron-remote-components-win-64.json
+++ b/versions-config/electron-remote-components-win-64.json
@@ -1,7 +1,7 @@
 {
   "ForceStable": false,
-  "LatestRolloutPercent": 2,
-  "InstallerElectronVersion": "2016.3.9.14.37",
+  "LatestRolloutPercent": 100,
+  "InstallerElectronVersion": "2016.2.24.17.21",
   "InstallerElectronURL": "http://install-versions.risevision.com/rvplayer-installer-win-64.tar.gz",
   "BrowserVersionStable": "48.0.2564.116",
   "BrowserVersionLatest": "48.0.2564.116",


### PR DESCRIPTION
@ahmedalsudani @fjvallarino please review.  **2016.2.24.17.21** is the installer version that's currently in production as rollback.  The other components are still as they were pre-rollback.