### PR TITLE
Bump "latest" player version so rollout pct is used

### DIFF
--- a/versions-config/remote-components-lnx-32.cfg
+++ b/versions-config/remote-components-lnx-32.cfg
@@ -22,7 +22,7 @@ JavaURLStable=http://install-versions.risevision.com/jre-7u80-linux-32.zip
 JavaURLLatest=http://install-versions.risevision.com/jre-7u80-linux-32.zip
 
 PlayerVersionStable=2016.03.09.10.00
-PlayerVersionLatest=2016.03.09.10.00
+PlayerVersionLatest=2016.04.05.10.00
 
 PlayerURLStable=http://install-versions.risevision.com/RisePlayer-2016-02-24-13-00.zip
 PlayerURLLatest=http://install-versions.risevision.com/RisePlayer-2016-02-24-13-00.zip

--- a/versions-config/remote-components-lnx-64.cfg
+++ b/versions-config/remote-components-lnx-64.cfg
@@ -22,7 +22,7 @@ JavaURLStable=http://install-versions.risevision.com/jre-7u80-linux-64.zip
 JavaURLLatest=http://install-versions.risevision.com/jre-7u80-linux-64.zip
 
 PlayerVersionStable=2016.03.09.10.00
-PlayerVersionLatest=2016.03.09.10.00
+PlayerVersionLatest=2016.04.05.10.00
 
 PlayerURLStable=http://install-versions.risevision.com/RisePlayer-2016-02-24-13-00.zip
 PlayerURLLatest=http://install-versions.risevision.com/RisePlayer-2016-02-24-13-00.zip

--- a/versions-config/remote-components-win.cfg
+++ b/versions-config/remote-components-win.cfg
@@ -22,7 +22,7 @@ JavaURLStable=http://install-versions.risevision.com/jre-7.9-32bit.zip
 JavaURLLatest=http://install-versions.risevision.com/jre-7.9-32bit.zip
 
 PlayerVersionStable=2016.03.09.10.00
-PlayerVersionLatest=2016.03.09.10.00
+PlayerVersionLatest=2016.04.05.10.00
 
 PlayerURLStable=http://install-versions.risevision.com/RisePlayer-2016-02-24-13-00.zip
 PlayerURLLatest=http://install-versions.risevision.com/RisePlayer-2016-02-24-13-00.zip


### PR DESCRIPTION
Otherwise the installer will move all components to latest effectively
putting us at 100% rollout.

@ahmedalsudani @fjvallarino please review